### PR TITLE
Fix `sbin` scripts for Grep v3+

### DIFF
--- a/system/sbin/kazoo-bigcouch
+++ b/system/sbin/kazoo-bigcouch
@@ -54,12 +54,10 @@ start() {
 }
 
 stop() {
-	for i in `pidof ${BEAM}`; do
-		if cat /proc/$i/cmdline | grep -Eq "name[^\-]+bigcouch"; then
-			kill $i
-			RETVAL=$?
-		fi
-	done
+	if PID=$(find_beam_pid); then
+		kill "$PID"
+		RETVAL=$?
+	fi
 }
 
 restart() {
@@ -71,34 +69,41 @@ status() {
     if [[ -f $CREDS_FILE ]]; then
         PASSWORD=$(cat $CREDS_FILE)
     fi
-	for i in `pidof ${BEAM}`; do
-		if cat /proc/$i/cmdline | grep -Eq "name[^\-]+bigcouch"; then
-			echo "BigCouch (pid $i) is running..."
-			if which curl &>/dev/null; then
-                if [[ -z $PASSWORD ]]; then
-                    curl localhost:5984/_membership
-                else
-                    curl localhost:5984/_membership -H "Authorization: Basic ${PASSWORD}"
-                fi
+	if PID=$(find_beam_pid); then
+		echo "BigCouch (pid $PID) is running..."
+
+		if which curl &>/dev/null; then
+			if [[ -z $PASSWORD ]]; then
+				curl localhost:5984/_membership
+			else
+				curl localhost:5984/_membership -H "Authorization: Basic ${PASSWORD}"
 			fi
-			RETVAL=0
 		fi
-	done
+
+		RETVAL=0
+	fi
 	if [ ${RETVAL} -eq 1 ]; then
 		echo "BigCouch is not running!"
 	fi
 }
 
 pid() {
-        for i in `pidof ${BEAM}`; do
-                if cat /proc/$i/cmdline | grep -Eq "name[^\-]+bigcouch"; then
-			echo $i
-                        RETVAL=0
-                fi
-        done
+	find_beam_pid
+	RETVAL=$?
 	if [ ${RETVAL} -eq 1 ]; then
 		echo "BigCouch is not running!"
 	fi
+}
+
+find_beam_pid() {
+	for PID in $(pidof $BEAM); do
+		if tr '\0' ' ' < /proc/"$PID"/cmdline | grep -Eq "name[^\-]+bigcouch"; then
+			echo "$PID"
+			return 0
+		fi
+	done
+
+	return 1
 }
 
 case "$1" in


### PR DESCRIPTION
Apply similar change as https://github.com/2600hz/kazoo-configs-core/pull/22

It seems when using Grep v3+ (not exactly sure on the breaking change version), that the `NUL` characters separating args in `/proc/$PID/cmdline` don't match the `[^\-]` character class. This means that the `beam` PIDs can't be found. This PR uses `tr` to replace the `NUL` characters with spaces so the `grep` succeeds. Tested backwards-compatibility with Grep v2.

Also DRY'd up the PID find with a shared function and ran these changes thru ShellCheck.